### PR TITLE
Add transport controls

### DIFF
--- a/src/utility/Midi.cpp
+++ b/src/utility/Midi.cpp
@@ -253,6 +253,45 @@ void Midi::receivePacket(uint8_t *data, uint8_t size)
     }
 }
 
+void Midi::play(void)
+{
+    uint8_t midiMessage[] = {
+        0xF0,	//sysex
+        0x7F, 	//
+        0x7F, 	//all devices
+        0x06, 	//MIDI Machine Control Command
+	0x02,	//play
+	0xF7	//end of sysex
+    };
+    sendMessage(midiMessage, sizeof(midiMessage));
+}
+
+void Midi::pause(void)
+{
+    uint8_t midiMessage[] = {
+        0xF0,	//sysex
+        0x7F, 	//
+        0x7F, 	//all devices
+        0x06, 	//MIDI Machine Control Command
+	0x09,	//pause
+	0xF7	//end of sysex
+    };
+    sendMessage(midiMessage, sizeof(midiMessage));
+}
+
+void Midi::stop(void)
+{
+    uint8_t midiMessage[] = {
+        0xF0,	//sysex
+        0x7F, 	//
+        0x7F, 	//all devices
+        0x06, 	//MIDI Machine Control Command
+	0x01,	//stop
+	0xF7	//end of sysex
+    };
+    sendMessage(midiMessage, sizeof(midiMessage));
+}
+
 void Midi::sendMessage(uint8_t *message, uint8_t messageSize)
 {
     uint8_t packet[messageSize+2];

--- a/src/utility/Midi.cpp
+++ b/src/utility/Midi.cpp
@@ -253,34 +253,83 @@ void Midi::receivePacket(uint8_t *data, uint8_t size)
     }
 }
 
-void Midi::play(void)
+void Midi::mmcPlay(void)
 {
     sendMMC(MMC_PLAY);
 }
 
-void Midi::pause(void)
+void Midi::mmcDeferredPlay(void)
+{
+    sendMMC(MMC_DEFERRED_PLAY);
+}
+
+void Midi::mmcPause(void)
 {
     sendMMC(MMC_PAUSE);
 }
 
-void Midi::stop(void)
+void Midi::mmcStop(void)
 {
     sendMMC(MMC_STOP);
 }
 
-void Midi::rec(void)
+void Midi::mmcRecordStrobe(void)
 {
-    sendMMC(MMC_REC);
+    sendMMC(MMC_RECORD_STROBE);
 }
+
+void Midi::mmcRecordExit(void)
+{
+    sendMMC(MMC_RECORD_EXIT);
+}
+
+void Midi::mmcRecordPause(void)
+{
+    sendMMC(MMC_RECORD_PAUSE);
+}
+
+void Midi::mmcEject(void)
+{
+    sendMMC(MMC_EJECT);
+}
+
+void Midi::mmcChase(void)
+{
+    sendMMC(MMC_CHASE);
+}
+
+void Midi::mmcReset(void)
+{
+    sendMMC(MMC_RESET);
+}
+
+void Midi::mmcFastForward(void)
+{
+    sendMMC(MMC_FAST_FORWARD);
+}
+
+void Midi::mmcRewind(void)
+{
+    sendMMC(MMC_REWIND);
+}
+
 
 void Midi::sendMMC(mmc_t command)
 {
     switch(command) 
     {
-        case 0x01:
-        case 0x02:
-        case 0x06:
-        case 0x09:
+        case MMC_STOP:
+        case MMC_PLAY:
+        case MMC_DEFERRED_PLAY:
+        case MMC_FAST_FORWARD:
+        case MMC_REWIND:
+        case MMC_RECORD_STROBE:
+        case MMC_RECORD_EXIT:
+        case MMC_RECORD_PAUSE:
+        case MMC_PAUSE:
+        case MMC_EJECT:
+        case MMC_CHASE:
+        case MMC_RESET:
             break;
         default:
             debug.print("Warning: Unsupported MMC command");

--- a/src/utility/Midi.cpp
+++ b/src/utility/Midi.cpp
@@ -255,54 +255,48 @@ void Midi::receivePacket(uint8_t *data, uint8_t size)
 
 void Midi::play(void)
 {
-    uint8_t midiMessage[] = {
-        0xF0,	//sysex
-        0x7F, 	//
-        0x7F, 	//all devices
-        0x06, 	//MIDI Machine Control Command
-	0x02,	//play
-	0xF7	//end of sysex
-    };
-    sendMessage(midiMessage, sizeof(midiMessage));
+    sendMMC(MMC_PLAY);
 }
 
 void Midi::pause(void)
 {
-    uint8_t midiMessage[] = {
-        0xF0,	//sysex
-        0x7F, 	//
-        0x7F, 	//all devices
-        0x06, 	//MIDI Machine Control Command
-	0x09,	//pause
-	0xF7	//end of sysex
-    };
-    sendMessage(midiMessage, sizeof(midiMessage));
+    sendMMC(MMC_PAUSE);
 }
 
 void Midi::stop(void)
 {
-    uint8_t midiMessage[] = {
-        0xF0,	//sysex
-        0x7F, 	//
-        0x7F, 	//all devices
-        0x06, 	//MIDI Machine Control Command
-	0x01,	//stop
-	0xF7	//end of sysex
-    };
-    sendMessage(midiMessage, sizeof(midiMessage));
+    sendMMC(MMC_STOP);
 }
 
 void Midi::rec(void)
 {
+    sendMMC(MMC_REC);
+}
+
+void Midi::sendMMC(mmc_t command)
+{
+    switch(command) 
+    {
+        case 0x01:
+        case 0x02:
+        case 0x06:
+        case 0x09:
+            break;
+        default:
+            debug.print("Warning: Unsupported MMC command");
+            break;
+    }
+
     uint8_t midiMessage[] = {
-        0xF0,	//sysex
-        0x7F, 	//
-        0x7F, 	//all devices
-        0x06, 	//MIDI Machine Control Command
-	0x06,	//stop
-	0xF7	//end of sysex
+        0xF0,    //sysex
+        0x7F,     //
+        0x7F,     //all devices
+        0x06,     //MIDI Machine Control Command
+        command,
+        0xF7    //end of sysex
     };
     sendMessage(midiMessage, sizeof(midiMessage));
+
 }
 
 

--- a/src/utility/Midi.cpp
+++ b/src/utility/Midi.cpp
@@ -292,6 +292,20 @@ void Midi::stop(void)
     sendMessage(midiMessage, sizeof(midiMessage));
 }
 
+void Midi::rec(void)
+{
+    uint8_t midiMessage[] = {
+        0xF0,	//sysex
+        0x7F, 	//
+        0x7F, 	//all devices
+        0x06, 	//MIDI Machine Control Command
+	0x06,	//stop
+	0xF7	//end of sysex
+    };
+    sendMessage(midiMessage, sizeof(midiMessage));
+}
+
+
 void Midi::sendMessage(uint8_t *message, uint8_t messageSize)
 {
     uint8_t packet[messageSize+2];

--- a/src/utility/Midi.h
+++ b/src/utility/Midi.h
@@ -50,7 +50,14 @@ protected:
     Debug debug;
 
 private:
+    enum mmc_t {
+        MMC_STOP  = 0x01,
+        MMC_PLAY  = 0x02,
+        MMC_REC   = 0x06,
+        MMC_PAUSE = 0x09,
+    };
     void sendMessage(uint8_t *message, uint8_t messageSize);
+    void sendMMC(mmc_t command);
     void (*noteOnCallback)(uint8_t, uint8_t, uint8_t, uint16_t) = nullptr;
     void (*noteOffCallback)(uint8_t, uint8_t, uint8_t, uint16_t) = nullptr;
     void (*afterTouchPolyCallback)(uint8_t, uint8_t, uint8_t, uint16_t) = nullptr;

--- a/src/utility/Midi.h
+++ b/src/utility/Midi.h
@@ -26,6 +26,10 @@ public:
      * @param range Range of the pitch bend in semitones (default value is 4, which is -2 to +2 semitones)
      * */
     void pitchBend(uint8_t channel, float semitones, float range = 4);
+    
+    void play(void);
+    void pause(void);
+    void stop(void);
 
     void setNoteOnCallback(void (*callback)(uint8_t channel, uint8_t note, uint8_t velocity, uint16_t timestamp));
     void setNoteOffCallback(void (*callback)(uint8_t channel, uint8_t note, uint8_t velocity, uint16_t timestamp));

--- a/src/utility/Midi.h
+++ b/src/utility/Midi.h
@@ -27,10 +27,19 @@ public:
      * */
     void pitchBend(uint8_t channel, float semitones, float range = 4);
     
-    void play(void);
-    void pause(void);
-    void stop(void);
-    void rec(void);
+    void mmcPlay(void);
+    void mmcDeferredPlay(void);
+    void mmcPause(void);
+    void mmcStop(void);
+    void mmcRecordStrobe(void);
+    void mmcRecordPause(void);
+    void mmcRecordExit(void);
+    void mmcEject(void);
+    void mmcChase(void);
+    void mmcReset(void);
+    void mmcFastForward(void);
+    void mmcRewind(void);
+    
 
     void setNoteOnCallback(void (*callback)(uint8_t channel, uint8_t note, uint8_t velocity, uint16_t timestamp));
     void setNoteOffCallback(void (*callback)(uint8_t channel, uint8_t note, uint8_t velocity, uint16_t timestamp));
@@ -51,10 +60,19 @@ protected:
 
 private:
     enum mmc_t {
-        MMC_STOP  = 0x01,
-        MMC_PLAY  = 0x02,
-        MMC_REC   = 0x06,
-        MMC_PAUSE = 0x09,
+        MMC_STOP          = 0x01,
+        MMC_PLAY          = 0x02,
+        MMC_DEFERRED_PLAY = 0x03,
+        MMC_FAST_FORWARD  = 0x04,
+        MMC_REWIND        = 0x05,
+        MMC_RECORD_STROBE = 0x06,
+        MMC_RECORD_EXIT   = 0x07,
+        MMC_RECORD_PAUSE  = 0x08,
+        MMC_PAUSE         = 0x09,
+        MMC_EJECT         = 0x0A,
+        MMC_CHASE         = 0x0B,
+        MMC_RESET         = 0x0D,
+        //TODO: Write, Goto, Shuttle
     };
     void sendMessage(uint8_t *message, uint8_t messageSize);
     void sendMMC(mmc_t command);

--- a/src/utility/Midi.h
+++ b/src/utility/Midi.h
@@ -30,6 +30,7 @@ public:
     void play(void);
     void pause(void);
     void stop(void);
+    void rec(void);
 
     void setNoteOnCallback(void (*callback)(uint8_t channel, uint8_t note, uint8_t velocity, uint16_t timestamp));
     void setNoteOffCallback(void (*callback)(uint8_t channel, uint8_t note, uint8_t velocity, uint16_t timestamp));


### PR DESCRIPTION
This adds MMC transport controls (play, pause, stop, record)

I've tested it with FL Studio Mobile.  It recognizes play as play/pause, but does not respond to Pause.  I'm wondering if other DAWs work the same.  I took the control command #'s from https://en.wikipedia.org/wiki/MIDI_Machine_Control