### PR TITLE
Fixes for latest NimBLE & adding device name to advertisement data

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32-BLE-MIDI
-version=0.3.2
+version=0.3.3
 author=Maxime ANDRÉ <maxime.andre1986@gmail.com>
 maintainer=Maxime ANDRÉ <maxime.andre1986@gmail.com>
 sentence=A library to use MIDI over Bluetooth Low Energy on ESP32 boards.

--- a/src/utility/BLEMidiClient.cpp
+++ b/src/utility/BLEMidiClient.cpp
@@ -16,10 +16,11 @@ int BLEMidiClientClass::scan()
     pBLEScan->setWindow(99);
     pBLEScan->clearResults();
     foundMidiDevices.clear();
-    BLEScanResults foundDevices = pBLEScan->start(3);
+    pBLEScan->start(3);
+    BLEScanResults foundDevices = pBLEScan->getResults();
     debug.printf("Found %d BLE device(s)\n", foundDevices.getCount());
     for(int i=0; i<foundDevices.getCount(); i++) {
-        BLEAdvertisedDevice device = foundDevices.getDevice(i);
+        BLEAdvertisedDevice device = *foundDevices.getDevice(i);
         auto deviceStr = "name = \"" + device.getName() + "\", address = "  + device.getAddress().toString();
         if (device.haveServiceUUID() && device.isAdvertisingService(BLEUUID(MIDI_SERVICE_UUID))) {
             debug.println((" - BLE MIDI device : " + deviceStr).c_str());

--- a/src/utility/BLEMidiServer.cpp
+++ b/src/utility/BLEMidiServer.cpp
@@ -16,6 +16,9 @@ void BLEMidiServerClass::begin(const std::string deviceName)
     pCharacteristic->setCallbacks(new CharacteristicCallback([this](uint8_t *data, uint8_t size) { this->receivePacket(data, size); }));
     pService->start();
     BLEAdvertising *pAdvertising = pServer->getAdvertising();
+    auto data = pAdvertising->getAdvertisementData();
+    data.setName(deviceName);
+    pAdvertising->setAdvertisementData(data);
     pAdvertising->addServiceUUID(pService->getUUID());
     pAdvertising->start();
 }
@@ -38,14 +41,14 @@ void BLEMidiServerClass::sendPacket(uint8_t *packet, uint8_t packetSize)
     pCharacteristic->notify();
 }
 
-void BLEMidiServerClass::onConnect(BLEServer* pServer)
+void BLEMidiServerClass::onConnect(BLEServer* pServer, NimBLEConnInfo& connInfo)
 {
     connected = true;
     if(onConnectCallback != nullptr)
         onConnectCallback();
 }
 
-void BLEMidiServerClass::onDisconnect(BLEServer* pServer)
+void BLEMidiServerClass::onDisconnect(BLEServer* pServer, NimBLEConnInfo& connInfo, int reason)
 {
     connected = false;
     if(onDisconnectCallback != nullptr)

--- a/src/utility/BLEMidiServer.h
+++ b/src/utility/BLEMidiServer.h
@@ -15,8 +15,8 @@ public:
 
 private:
     virtual void sendPacket(uint8_t *packet, uint8_t packetSize) override;
-    void onConnect(BLEServer* pServer) override;
-    void onDisconnect(BLEServer* pServer) override;
+    void onConnect(BLEServer* pServer, NimBLEConnInfo& connInfo) override;
+    void onDisconnect(BLEServer* pServer, NimBLEConnInfo& connInfo, int reason) override;
     
     void (*onConnectCallback)() = nullptr;
     void (*onDisconnectCallback)() = nullptr;


### PR DESCRIPTION
- Latest version of the [NimBLEServer.h](https://github.com/h2zero/esp-nimble-cpp/blob/master/src/NimBLEServer.h) breaks the build (signatures of `onConnect` and `onDisconnect` changed, as well as [`start`](https://github.com/h2zero/esp-nimble-cpp/blob/master/src/NimBLEScan.h#L69)).
- Device was shown as having no name on Android devices (which made it unselectable in e.g. [TouchOSC](https://hexler.net/touchosc)); added the `deviceName` explicitly to the advertisement data, which solved the issue.